### PR TITLE
Some fixes for MSVC2010

### DIFF
--- a/Source/Base/Base/OSGContainerForwards.h
+++ b/Source/Base/Base/OSGContainerForwards.h
@@ -75,12 +75,12 @@
 #endif
 
 #define OSG_GEN_CONTAINERPTR(CLASST)                                          \
-    OSG_GEN_COMPAT_CONTAINERPTR(CLASST)                                       \
     typedef TransitPtr   < CLASST                  > CLASST##TransitPtr;      \
     typedef MTRefCountPtr< CLASST,                                            \
                            NoRefCountPolicy        > CLASST##MTUncountedPtr;  \
     typedef RefCountPtr  < CLASST,                                            \
                            RecordedRefCountPolicy  > CLASST##RecPtr;          \
+    OSG_GEN_COMPAT_CONTAINERPTR(CLASST)                                       \
     typedef RefCountPtr  < CLASST,                                            \
                            UnrecordedRefCountPolicy> CLASST##UnrecPtr;        \
     typedef RefCountPtr  < CLASST,                                            \

--- a/Source/Base/FieldContainer/Base/OSGThread.h
+++ b/Source/Base/FieldContainer/Base/OSGThread.h
@@ -422,10 +422,10 @@ class WinThreadBase : public ThreadCommonBase
     /*! \{                                                                 */
 
 #if defined(OSG_WIN32_ASPECT_USE_LOCALSTORAGE)
-    static UInt32 _aspectKey;
-    static UInt32 _changeListKey;
-    static UInt32 _namespaceMaskKey;
-    static UInt32 _localFlagsKey;
+    OSG_BASE_DLLMAPPING static UInt32 _aspectKey;
+    OSG_BASE_DLLMAPPING static UInt32 _changeListKey;
+    OSG_BASE_DLLMAPPING static UInt32 _namespaceMaskKey;
+    OSG_BASE_DLLMAPPING static UInt32 _localFlagsKey;
 #else
     static __declspec (thread) UInt32      _uiAspectLocal;
     static __declspec (thread) ChangeList *_pChangeListLocal;

--- a/Source/Contrib/WebInterface/OSGWebInterface.h
+++ b/Source/Contrib/WebInterface/OSGWebInterface.h
@@ -43,13 +43,13 @@
 #include <map>
 #include <sstream>
 
-#include <OSGConfig.h>
-#include <OSGContribWebInterfaceDef.h>
+#include <OpenSG/OSGConfig.h>
+#include <OpenSG/OSGContribWebInterfaceDef.h>
 
-#include <OSGStreamSocket.h>
-#include <OSGBaseTypes.h>
-#include <OSGMemoryObject.h>
-#include <OSGNode.h>
+#include <OpenSG/OSGStreamSocket.h>
+#include <OpenSG/OSGBaseTypes.h>
+#include <OpenSG/OSGMemoryObject.h>
+#include <OpenSG/OSGNode.h>
 
 OSG_BEGIN_NAMESPACE
 

--- a/Tools/fcd2code/FieldContainer.py
+++ b/Tools/fcd2code/FieldContainer.py
@@ -131,7 +131,7 @@ class FieldContainer(FCDElement):
         if self.getFCD("docGroupBase") != "":
             self["DocGroupBase"] = self.getFCD("docGroupBase")
         else:
-            self["DocGroupBase"] = "Grp" + self["Libname"]
+            self["DocGroupBase"] = "Grp" + str(self["Libname"])
         
         if self.getFCD("name") != "":
             self["Classname"] = self.getFCD("name");

--- a/Tools/fcd2code/TemplateFieldContainerBase_cpp.txt
+++ b/Tools/fcd2code/TemplateFieldContainerBase_cpp.txt
@@ -280,8 +280,8 @@ void @!Classname!@Base::classDescInserter(TypeObject &oType)
 @@else // isAbstract
     reinterpret_cast<PrototypeCreateF>(&@!Classname!@Base::createEmptyLocal),
 @@endif // isAbstract
-    @!Classname!@::initMethod,
-    @!Classname!@::exitMethod,
+    reinterpret_cast<InitContainerF>(&@!Classname!@::initMethod),
+    reinterpret_cast<ExitContainerF>(&@!Classname!@::exitMethod),
     reinterpret_cast<InitalInsertDescFunc>(&@!Classname!@::classDescInserter),
     @!TypeDescAddable!@,
     @!FieldsUnmarkedOnCreate!@,

--- a/Tools/fcd2code/TemplateFieldContainerBase_cpp.txt
+++ b/Tools/fcd2code/TemplateFieldContainerBase_cpp.txt
@@ -58,6 +58,11 @@
 #include <cstdlib>
 #include <cstdio>
 
+#ifdef WIN32 
+#pragma warning(disable: 4355) // turn off 'this' : used in base member initializer list warning
+#pragma warning(disable: 4290) // disable exception specification warning
+#endif
+
 #include "@!HeaderPrefix!@@!Package!@Config.h"
 
 @@AdditionalIncludes@@
@@ -80,10 +85,6 @@
 #include "OSG@!nsFilePrefix!@@!Classname!@.h"
 
 #include <boost/bind.hpp>
-
-#ifdef WIN32 // turn off 'this' : used in base member initializer list warning
-#pragma warning(disable:4355)
-#endif
 
 OSG_BEGIN_NAMESPACE
 

--- a/Tools/fcd2code/TemplateWriter.py
+++ b/Tools/fcd2code/TemplateWriter.py
@@ -33,7 +33,7 @@ class TemplateWriter:
         fileObj = open(self.m_fileName, openMode);
         
         self.m_log.debug("write: writing template.");
-        fileObj.writelines(self.m_filledTemplate);
+        fileObj.writelines(map(lambda (x): x.encode("UTF-8"), self.m_filledTemplate));
         
         self.m_log.debug("write: closing file.");
         fileObj.close();

--- a/Tools/fcd2code/fcd2code
+++ b/Tools/fcd2code/fcd2code
@@ -102,10 +102,10 @@ class FCDProcess:
                 rootPath = os.environ["OSG_ROOT"];
             else:
                 rootPath = os.getcwd();
-                rootPath = rootPath.replace("/Tools/fcd2code", "");
+                rootPath = rootPath.replace(os.path.sep + "Tools" + os.path.sep + "fcd2code", "");
         
         if rootPath != "":
-            tmplPath = os.path.join(rootPath, "Tools/fcd2code");
+            tmplPath = os.path.join(rootPath, "Tools" + os.path.sep + "fcd2code");
             self.m_log.info("Setting tmplPath \"%s\"", tmplPath);
 
         if OptionHandler.getOptionActive("templatePath"):


### PR DESCRIPTION
Hi!

It's nice to be back in the C++/OpenSG game again after 2 years away. :)

I've been tasked to help a company upgrade from OSG 1.x to OSG 2.

Below are some minor fixes that had to be done to make it compile on MSVC2010 with OSG_1_COMPAT defined, and to get fcd2code running under windows and generate files that would compile on MSVC2010.

They had some workaround code accessing OSG::Thread internals so I had to DLL-export those, otherwise there were no big issues.

The goal is 64-bit and 2013, so there might be a few more updates coming.